### PR TITLE
Include api with command params

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -90,6 +90,7 @@ async function cli(args: ParsedArgs) {
   }
 
   const api = await getApiDefinitions(args.remote_api_defs)
+  commandParams['api'] = api
 
   const selectedCommand = await interactForCommandSelection(args._, { api })
   if (isEqual(selectedCommand, ["login"])) {


### PR DESCRIPTION
API definition expected to be a part of CommandHelper.

Resolves #39